### PR TITLE
Change alpine base image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine
 RUN apk add -U --no-cache iptables
 COPY entry /usr/bin/
 CMD ["entry"]


### PR DESCRIPTION
This will fix the warning we get while scanning and give us more reliable vulnerability detection
```
$ trivy image -s HIGH,CRITICAL rancher/klipper-lb:42b03dd-amd64 
2021-07-20T11:54:23.274-0700    INFO    Detected OS: alpine
2021-07-20T11:54:23.275-0700    INFO    Detecting Alpine vulnerabilities...
2021-07-20T11:54:23.277-0700    INFO    Number of language-specific files: 0
2021-07-20T11:54:23.277-0700    WARN    This OS version is no longer supported by the distribution: alpine 3.8.5
2021-07-20T11:54:23.277-0700    WARN    The vulnerability detection may be insufficient because security updates are not provided

rancher/klipper-lb:ba66be0-amd64 (alpine 3.8.5)
===============================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```