### PR TITLE
Update build image toolchain

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,29 +1,17 @@
-FROM golang:1.11-alpine
-# FROM arm=golang@sha256:9677abaf94d699258b23e107fc6aaa8935938b1f3cb9c79ada24045e5aeebee4
+FROM golang:1.16-alpine3.12
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
-RUN go get -d golang.org/x/lint/golint && \
-    git -C /go/src/golang.org/x/lint/golint checkout -b current 06c8688daad7faa9da5a0c2f163a3d14aac986ca && \
-    go install golang.org/x/lint/golint && \
-    rm -rf /go/src /go/pkg
-RUN go get -d github.com/alecthomas/gometalinter && \
-    git -C /go/src/github.com/alecthomas/gometalinter checkout -b current v3.0.0 && \
-    go install github.com/alecthomas/gometalinter && \
-    gometalinter --install && \
-    rm -rf /go/src /go/pkg
-RUN go get -d github.com/rancher/trash && \
-    git -C /go/src/github.com/rancher/trash checkout -b current v0.2.6 && \
-    go install github.com/rancher/trash && \
-    rm -rf /go/src /go/pkg
+RUN if [ "$(go env GOARCH)" = "amd64" ]; then \
+    curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.0; \
+    fi
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/klipper-lb/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
-ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 RUN apk add -U --no-cache iptables
 COPY entry /usr/bin/
 CMD ["entry"]

--- a/package/Dockerfile.arm
+++ b/package/Dockerfile.arm
@@ -1,4 +1,0 @@
-FROM alpine@sha256:6d94d2806ccbe3b6036b2cd55c61260f474692b6987c21386e32ef54bc40200a
-RUN apk add -U --no-cache iptables
-COPY entry /usr/bin/
-CMD ["entry"]


### PR DESCRIPTION
Based on what was done in klipper-helm:
https://github.com/k3s-io/klipper-helm/pull/27
Apply similar changes

Note: Assuming 6d94d2806ccbe3b6036b2cd55c61260f474692b6987c21386e32ef54bc40200a is part of `alpine:3.12` but I could not check it

Signed-off-by: Manuel Buil <mbuil@suse.com>