### PR TITLE
Remove Dockerfile.arm from .drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -105,7 +105,7 @@ steps:
 - name: docker-publish
   image: plugins/docker
   settings:
-    dockerfile: package/Dockerfile.arm
+    dockerfile: package/Dockerfile
     password:
       from_secret: docker_password
     repo: "rancher/klipper-lb"


### PR DESCRIPTION
In a previous commit  Dockerfile.arm  was removed but .drone.yaml was not updated

Signed-off-by: Manuel Buil <mbuil@suse.com>