### PR TITLE
Fix arm bug by creating a specific Dockerfile for arm

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -105,7 +105,7 @@ steps:
 - name: docker-publish
   image: plugins/docker
   settings:
-    dockerfile: package/Dockerfile
+    dockerfile: package/Dockerfile.arm
     password:
       from_secret: docker_password
     repo: "rancher/klipper-lb"

--- a/package/Dockerfile.arm
+++ b/package/Dockerfile.arm
@@ -1,0 +1,5 @@
+# Alpine has a different image for arm https://github.com/docker-library/repo-info/blob/master/repos/alpine/remote/3.12.8.md
+FROM alpine@sha256:a296b4c6f6ee2b88f095b61e95c7ef4f51ba25598835b4978c9256d8c8ace48a
+RUN apk add -U --no-cache iptables
+COPY entry /usr/bin/
+CMD ["entry"]


### PR DESCRIPTION
It uses the 3.12 image that supports all arm versions ==> https://github.com/docker-library/repo-info/blob/master/repos/alpine/remote/3.12.8.md#alpine3128.

Linked issue: https://github.com/k3s-io/k3s/issues/4048

Signed-off-by: Manuel Buil <mbuil@suse.com>