### PR TITLE
Remove editing /proc/sys/net/ipv4/ip_forward

### DIFF
--- a/entry
+++ b/entry
@@ -3,8 +3,6 @@ set -e -x
 
 trap exit TERM INT
 
-echo 1 > /proc/sys/net/ipv4/ip_forward || true
-
 if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then
     exit 1
 fi


### PR DESCRIPTION
Containers can't modify `/proc/sys/net` parameters unless they are privileged or they add SecurityContext.sysctl permissions (kubelet must also whitelist those). As svc-lb pods don't have those configs set, it is impossible for them to modify it. Therefore, we always get the harmless but annoying log:

`/usr/bin/entry: line 12: can't create /proc/sys/net/ipv4/ip_forward: Read-only file system`

This PR removes that useless line

Signed-off-by: Manuel Buil <mbuil@suse.com>