### PR TITLE
Provide support for ipv6

### DIFF
--- a/entry
+++ b/entry
@@ -3,12 +3,20 @@ set -e -x
 
 trap exit TERM INT
 
-if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then
-    exit 1
+if echo ${DEST_IP} | grep -Eq ":" 
+then
+    if [ `cat /proc/sys/net/ipv6/conf/all/forwarding` != 1 ]; then
+        exit 1
+    fi
+    ip6tables -t nat -I PREROUTING ! -s ${DEST_IP}/128 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${DEST_IP}:${DEST_PORT}
+    ip6tables -t nat -I POSTROUTING -d ${DEST_IP}/128 -p ${DEST_PROTO} -j MASQUERADE
+else
+    if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then
+        exit 1
+    fi
+    iptables -t nat -I PREROUTING ! -s ${DEST_IP}/32 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${DEST_IP}:${DEST_PORT}
+    iptables -t nat -I POSTROUTING -d ${DEST_IP}/32 -p ${DEST_PROTO} -j MASQUERADE
 fi
-
-iptables -t nat -I PREROUTING ! -s ${DEST_IP}/32 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${DEST_IP}:${DEST_PORT}
-iptables -t nat -I POSTROUTING -d ${DEST_IP}/32 -p ${DEST_PROTO} -j MASQUERADE
 
 if [ ! -e /pause ]; then
     mkfifo /pause

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
 FROM alpine:3.12
-RUN apk add -U --no-cache iptables
+RUN apk add -U --no-cache iptables ip6tables
 COPY entry /usr/bin/
 CMD ["entry"]

--- a/package/Dockerfile.arm
+++ b/package/Dockerfile.arm
@@ -1,5 +1,5 @@
 # Alpine has a different image for arm https://github.com/docker-library/repo-info/blob/master/repos/alpine/remote/3.12.8.md
 FROM alpine@sha256:a296b4c6f6ee2b88f095b61e95c7ef4f51ba25598835b4978c9256d8c8ace48a
-RUN apk add -U --no-cache iptables
+RUN apk add -U --no-cache iptables ip6tables
 COPY entry /usr/bin/
 CMD ["entry"]


### PR DESCRIPTION
If the clusterIP is ipv6, then the ip6tables rules should apply.

The rules basically DNAT the traffic so that they are propagated into the clusterIP of the service

Linked issue: https://github.com/k3s-io/k3s/issues/4021

Signed-off-by: Manuel Buil <mbuil@suse.com>