### PR TITLE
Support multiple clusterIPs

### DIFF
--- a/entry
+++ b/entry
@@ -3,20 +3,23 @@ set -e -x
 
 trap exit TERM INT
 
-if echo ${DEST_IP} | grep -Eq ":" 
-then
-    if [ `cat /proc/sys/net/ipv6/conf/all/forwarding` != 1 ]; then
-        exit 1
+for dest_ip in ${DEST_IPs}
+do
+    if echo ${dest_ip} | grep -Eq ":" 
+    then
+        if [ `cat /proc/sys/net/ipv6/conf/all/forwarding` != 1 ]; then
+            exit 1
+        fi
+        ip6tables -t nat -I PREROUTING ! -s ${dest_ip}/128 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
+        ip6tables -t nat -I POSTROUTING -d ${dest_ip}/128 -p ${DEST_PROTO} -j MASQUERADE
+    else
+        if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then
+            exit 1
+        fi
+        iptables -t nat -I PREROUTING ! -s ${dest_ip}/32 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
+        iptables -t nat -I POSTROUTING -d ${dest_ip}/32 -p ${DEST_PROTO} -j MASQUERADE
     fi
-    ip6tables -t nat -I PREROUTING ! -s ${DEST_IP}/128 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${DEST_IP}:${DEST_PORT}
-    ip6tables -t nat -I POSTROUTING -d ${DEST_IP}/128 -p ${DEST_PROTO} -j MASQUERADE
-else
-    if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then
-        exit 1
-    fi
-    iptables -t nat -I PREROUTING ! -s ${DEST_IP}/32 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${DEST_IP}:${DEST_PORT}
-    iptables -t nat -I POSTROUTING -d ${DEST_IP}/32 -p ${DEST_PROTO} -j MASQUERADE
-fi
+done
 
 if [ ! -e /pause ]; then
     mkfifo /pause


### PR DESCRIPTION
I forgot to add support for dual-stack services that include two clusterIPs, for example:
```
  clusterIPs:
  - 10.43.189.134
  - 2001:cafe:42:1::51f4
```

Signed-off-by: Manuel Buil <mbuil@suse.com>