### PR TITLE
Comply with the ipv6 notation

### DIFF
--- a/entry
+++ b/entry
@@ -10,7 +10,7 @@ do
         if [ `cat /proc/sys/net/ipv6/conf/all/forwarding` != 1 ]; then
             exit 1
         fi
-        ip6tables -t nat -I PREROUTING ! -s ${dest_ip}/128 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
+        ip6tables -t nat -I PREROUTING ! -s ${dest_ip}/128 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to [${dest_ip}]:${DEST_PORT}
         ip6tables -t nat -I POSTROUTING -d ${dest_ip}/128 -p ${DEST_PROTO} -j MASQUERADE
     else
         if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then


### PR DESCRIPTION
When writing an ip and a port, the ipv6 part should be inside brackets 

Signed-off-by: Manuel Buil <mbuil@suse.com>