### PR TITLE
Drop arm Dockerfile; fix drone step arch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -89,7 +89,7 @@ type: docker
 
 platform:
   os: linux
-  arch: arm64
+  arch: arm
 
 steps:
 - name: build
@@ -105,7 +105,6 @@ steps:
 - name: docker-publish
   image: plugins/docker
   settings:
-    dockerfile: package/Dockerfile.arm
     password:
       from_secret: docker_password
     repo: "rancher/klipper-lb"

--- a/package/Dockerfile.arm
+++ b/package/Dockerfile.arm
@@ -1,5 +1,0 @@
-# Alpine has a different image for arm https://github.com/docker-library/repo-info/blob/master/repos/alpine/remote/3.12.8.md
-FROM alpine@sha256:a296b4c6f6ee2b88f095b61e95c7ef4f51ba25598835b4978c9256d8c8ace48a
-RUN apk add -U --no-cache iptables ip6tables
-COPY entry /usr/bin/
-CMD ["entry"]


### PR DESCRIPTION
Dockerfile.arm pointed at a multiarch manifest list, and the drone config was set up to run on arm64, so we were still just building arm images on and for the wrong platform.

* https://github.com/k3s-io/k3s/issues/4384