### PR TITLE
Bump alpine version; enforce .spec.loadBalancerSourceRanges

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.12
+FROM golang:1.19-alpine3.16
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/entry
+++ b/entry
@@ -3,19 +3,23 @@ set -e -x
 
 trap exit TERM INT
 
-for dest_ip in ${DEST_IPS}
-do
-    if echo ${dest_ip} | grep -Eq ":" 
-    then
-        if [ `cat /proc/sys/net/ipv6/conf/all/forwarding` != 1 ]; then
-            exit 1
-        fi
+for src_range in ${SRC_RANGES}; do
+    if echo ${src_range} | grep -Eq ":"; then
+        ip6tables -t filter -I FORWARD -s ${src_range} -p ${DEST_PROTO} --dport ${SRC_PORT} -j ACCEPT
+    else
+        iptables -t filter -I FORWARD -s ${src_range} -p ${DEST_PROTO} --dport ${SRC_PORT} -j ACCEPT
+    fi
+done
+
+for dest_ip in ${DEST_IPS}; do
+    if echo ${dest_ip} | grep -Eq ":"; then
+        [ $(cat /proc/sys/net/ipv6/conf/all/forwarding) == 1 ] || exit 1
+        ip6tables -t filter -A FORWARD -d ${dest_ip}/128 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
         ip6tables -t nat -I PREROUTING ! -s ${dest_ip}/128 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to [${dest_ip}]:${DEST_PORT}
         ip6tables -t nat -I POSTROUTING -d ${dest_ip}/128 -p ${DEST_PROTO} -j MASQUERADE
     else
-        if [ `cat /proc/sys/net/ipv4/ip_forward` != 1 ]; then
-            exit 1
-        fi
+        [ $(cat /proc/sys/net/ipv4/ip_forward) == 1 ] || exit 1
+        iptables -t filter -A FORWARD -d ${dest_ip}/32 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
         iptables -t nat -I PREROUTING ! -s ${dest_ip}/32 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
         iptables -t nat -I POSTROUTING -d ${dest_ip}/32 -p ${DEST_PROTO} -j MASQUERADE
     fi

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:3.15.4
-RUN apk add -U --no-cache iptables ip6tables
+FROM alpine:3.16
+ARG BUILDDATE
+LABEL buildDate=$BUILDDATE
+RUN apk --no-cache upgrade && \
+    apk add -U --no-cache iptables ip6tables
 COPY entry /usr/bin/
 CMD ["entry"]

--- a/scripts/package
+++ b/scripts/package
@@ -21,5 +21,5 @@ if [ -e ${DOCKERFILE}.${ARCH} ]; then
     DOCKERFILE=${DOCKERFILE}.${ARCH}
 fi
 
-docker build -f ${DOCKERFILE} -t ${IMAGE} .
+docker build --build-arg BUILDDATE=$(date +%Y%m%d) -f ${DOCKERFILE} -t ${IMAGE} .
 echo Built ${IMAGE}


### PR DESCRIPTION
Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#:~:text=loadBalancerSourceRanges

Also, inject BUILDDATE as cache-bust to ensure that packages get updated in final stage to address vulns.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>