### PR TITLE
Fix iptables filtering rules when externalTrafficPolicy is Local

### DIFF
--- a/entry
+++ b/entry
@@ -41,9 +41,9 @@ set_legacy() {
 start_proxy() {
     for src_range in ${SRC_RANGES}; do
     if echo ${src_range} | grep -Eq ":"; then
-        ip6tables -t filter -I FORWARD -s ${src_range} -p ${DEST_PROTO} --dport ${SRC_PORT} -j ACCEPT
+        ip6tables -t filter -I FORWARD -s ${src_range} -p ${DEST_PROTO} --dport ${DEST_PORT} -j ACCEPT
     else
-        iptables -t filter -I FORWARD -s ${src_range} -p ${DEST_PROTO} --dport ${SRC_PORT} -j ACCEPT
+        iptables -t filter -I FORWARD -s ${src_range} -p ${DEST_PROTO} --dport ${DEST_PORT} -j ACCEPT
     fi
     done
 

--- a/entry
+++ b/entry
@@ -51,12 +51,12 @@ start_proxy() {
         if echo ${dest_ip} | grep -Eq ":"; then
             [ $(cat /proc/sys/net/ipv6/conf/all/forwarding) == 1 ] || exit 1
             ip6tables -t filter -A FORWARD -d ${dest_ip}/128 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
-            ip6tables -t nat -I PREROUTING ! -s ${dest_ip}/128 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to [${dest_ip}]:${DEST_PORT}
+            ip6tables -t nat -I PREROUTING -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to [${dest_ip}]:${DEST_PORT}
             ip6tables -t nat -I POSTROUTING -d ${dest_ip}/128 -p ${DEST_PROTO} -j MASQUERADE
         else
             [ $(cat /proc/sys/net/ipv4/ip_forward) == 1 ] || exit 1
             iptables -t filter -A FORWARD -d ${dest_ip}/32 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
-            iptables -t nat -I PREROUTING ! -s ${dest_ip}/32 -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
+            iptables -t nat -I PREROUTING -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
             iptables -t nat -I POSTROUTING -d ${dest_ip}/32 -p ${DEST_PROTO} -j MASQUERADE
         fi
     done


### PR DESCRIPTION
Hello,

I started using k3s and its default klipper-lb installation a few days ago and noticed that the svclb pod's iptables rules are not working when LoadBalancer service's `externalTrafficPolicy` is `Local`. (k3s version v1.26.3+k3s1 (01ea3ff2), rancher/klipper-lb:v0.4.0, kernel: 5.15.0-1034-oracle)
When LoadBalancer service's `externalTrafficPolicy` is `Local`, `SRC_PORT` (service's port) and `DEST_PORT` (node port) is different.
Because PREROUTING rules are applied *before* FORWARD rules, FORWARD rules in L44 and L46 need to specify `DEST_PORT` as destination ports which is rewritten in L54 and L59.
As far as I know, this bug was introduced in #42.

Additional context:

If a node has external IP configured, the IP is populated into `status.loadBalancer.ingress` ip list, which in turn instructs k8s itself to configure iptables rule to directly forward traffic to service pods.
So, for nodes with external IP, traffic destined to the external IP correctly reaches service pods.
For example:
```
Chain KUBE-SERVICES (2 references)
target     prot opt source               destination         
KUBE-EXT-6LG7QS4WGVG7546G  tcp  --  anywhere             {{ node's external ip }}  /* {{ service name }} loadbalancer IP */ tcp dpt:{{ service port }}
```
> If the ServiceLB Pod runs on a node that has an external IP configured, the node's external IP is populated into the Service's status.loadBalancer.ingress address list. Otherwise, the node's internal IP is used.
https://docs.k3s.io/networking

However, if a node doesn't have an external IP or traffic is not destined to node's external IP (e.g. to localhost or to some other IP assigned to the node), the traffic is routed to svclb pods which listens on hostIP 0.0.0.0/0.
This is where I noticed that svclb pods weren't handling packets correctly.