### PR TITLE
Add support for RISC-V

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -138,6 +138,52 @@ volumes:
 
 ---
 kind: pipeline
+name: riscv64
+type: docker
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: docker:25.0-git
+  environment:
+    ARCH: "riscv64"
+  commands:
+  - apk add make
+  - git config --global --add safe.directory /drone/src
+  - make
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+
+- name: docker-publish
+  image: plugins/docker
+  settings:
+    dockerfile: Dockerfile
+    password:
+      from_secret: docker_password
+    repo: "rancher/klipper-lb"
+    tag: "${DRONE_TAG}-riscv64"
+    username:
+      from_secret: docker_username
+  when:
+    instance:
+    - drone-publish.k3s.io
+    ref:
+    - refs/head/master
+    - refs/tags/*
+    event:
+    - tag
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock
+
+---
+kind: pipeline
 name: manifest
 type: docker
 
@@ -157,6 +203,7 @@ steps:
       - linux/amd64
       - linux/arm64
       - linux/arm
+      - linux/riscv64
     target: "rancher/klipper-lb:${DRONE_TAG}"
     template: "rancher/klipper-lb:${DRONE_TAG}-ARCH"
   when:
@@ -172,3 +219,4 @@ depends_on:
 - amd64
 - arm64
 - arm
+- riscv64

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
+DOCKER_ARGS=
+ifeq ($(ARCH),riscv64)
+	export DOCKER_BUILDKIT = 1
+	DOCKER_ARGS=--platform=linux/riscv64
+endif
+
 .DEFAULT_GOAL := ci
 .PHONY: ci
 ci:
-	@. ./scripts/version; docker build --build-arg BUILDDATE=$(date +%Y%m%d) -f Dockerfile -t $${IMAGE} .
+	@. ./scripts/version; docker build ${DOCKER_ARGS} --build-arg BUILDDATE=$(date +%Y%m%d) -f Dockerfile -t $${IMAGE} .
 	@. ./scripts/version; echo Built $${IMAGE}


### PR DESCRIPTION
The work is part of an ongoing effort to run [K3s on RISC-V](https://github.com/k3s-io/k3s/pull/7778). In K3s, klipper-lb is part of the default deployment.

The resulting container image is built with `ARCH=riscv64 make`.