### PR TITLE
Install iptables-legacy package

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:3.19
 ARG BUILDDATE
 LABEL buildDate=$BUILDDATE
 RUN apk --no-cache upgrade && \
-    apk add -U --no-cache iptables ip6tables nftables
+    apk add -U --no-cache iptables ip6tables nftables iptables-legacy
 COPY entry /usr/bin/
 CMD ["entry"]


### PR DESCRIPTION
Install iptables-legacy package or we will not get `/sbin/xtables-legacy-multi` since Alpine 3.19, which breaks the image for underlying OS still using iptables-legacy (e.g. Ubuntu 20)