### PR TITLE
Only enable forwarding for each AF if the sysctl is enabled

### DIFF
--- a/entry
+++ b/entry
@@ -66,15 +66,17 @@ start_proxy() {
 
     for dest_ip in ${DEST_IPS//,/ }; do
         if echo ${dest_ip} | grep -Eq ":"; then
-            [ $(cat /proc/sys/net/ipv6/conf/all/forwarding) == 1 ] || exit 1
-            ip6tables -t filter -A FORWARD -d ${dest_ip}/128 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
-            ip6tables -t nat -I PREROUTING -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to [${dest_ip}]:${DEST_PORT}
-            ip6tables -t nat -I POSTROUTING -d ${dest_ip}/128 -p ${DEST_PROTO} -j MASQUERADE
+            if [ $(cat /proc/sys/net/ipv6/conf/all/forwarding) == 1 ]; then
+                ip6tables -t filter -A FORWARD -d ${dest_ip}/128 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
+                ip6tables -t nat -I PREROUTING -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to [${dest_ip}]:${DEST_PORT}
+                ip6tables -t nat -I POSTROUTING -d ${dest_ip}/128 -p ${DEST_PROTO} -j MASQUERADE
+            fi
         else
-            [ $(cat /proc/sys/net/ipv4/ip_forward) == 1 ] || exit 1
-            iptables -t filter -A FORWARD -d ${dest_ip}/32 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
-            iptables -t nat -I PREROUTING -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
-            iptables -t nat -I POSTROUTING -d ${dest_ip}/32 -p ${DEST_PROTO} -j MASQUERADE
+            if [ $(cat /proc/sys/net/ipv4/ip_forward) == 1 ]; then
+                iptables -t filter -A FORWARD -d ${dest_ip}/32 -p ${DEST_PROTO} --dport ${DEST_PORT} -j DROP
+                iptables -t nat -I PREROUTING -p ${DEST_PROTO} --dport ${SRC_PORT} -j DNAT --to ${dest_ip}:${DEST_PORT}
+                iptables -t nat -I POSTROUTING -d ${dest_ip}/32 -p ${DEST_PROTO} -j MASQUERADE
+            fi
         fi
     done
 }


### PR DESCRIPTION
The sysctls will be enabled for whatever AFs we need to forward for, don't fail if one is not enabled but we have a dest address of that AF.

This may occur when there is a single-stack service with `externalTrafficPolicy: local` on a dual-stack node. We will have dual-stack destination addresses (set based on node IPs), but we should only forward for the AFs used by the backing service, which can be determined by looking at the sysctls.