### PR TITLE
Remove old dependabot rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,6 @@ updates:
       - "k3s-io/k3s-dev"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "docker"
-    directory: "/package"
-    labels:
-      - "kind/dependabot"
-    reviewers:
-      - "k3s-io/k3s-dev"
-    schedule:
-      interval: "weekly"
   
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Dependabot fails because there is not `package/Dockerfile` anymore

Signed-off-by: Derek Nola <derek.nola@suse.com>